### PR TITLE
Call glyph.getAddress() rather than the undefined glyph.address

### DIFF
--- a/src/test/coffee/harfbuzzTest.coffee
+++ b/src/test/coffee/harfbuzzTest.coffee
@@ -88,7 +88,7 @@ glyph_func = harfbuzz.callback harfbuzz.Bool, "glyph_func", {
 		glyph: harfbuzz.ptr(harfbuzz.hb_codepoint_t),
 		user_data: harfbuzz.ptr(harfbuzz.Void)
 	}, (font, font_data, unicode, variant_selector, glyph, user_data) ->
-		harfbuzz.setValue glyph.address, unicode, "i32"
+		harfbuzz.setValue glyph.getAddress(), unicode, "i32"
 		console.log "Called with unicode: #{unicode}, glyph is #{glyph.get()}"
 
 		return true


### PR DESCRIPTION
Is this right? The glyph numbers seem to make more sense now.

```
$ ./gradlew check

...
Called with unicode: 66, glyph is 66
Called with unicode: 97, glyph is 97
Called with unicode: 99, glyph is 99
Called with unicode: 111, glyph is 111
Called with unicode: 110, glyph is 110
Advance for 66 is 9
Advance for 97 is 9
Advance for 99 is 9
Advance for 111 is 9
Advance for 110 is 5
Buffer length: 5
Ptr'd len: null
Glyph #0: { codepoint: 66, mask: 1, cluster: 0, var1: 2, var2: 9 } at { x_advance: 9, y_advance: 0, x_offset: 0, y_offset: 0, var: 0 }
Glyph #1: { codepoint: 97, mask: 1, cluster: 1, var1: 2, var2: 5 } at { x_advance: 9, y_advance: 0, x_offset: 0, y_offset: 0, var: 0 }
Glyph #2: { codepoint: 99, mask: 1, cluster: 2, var1: 2, var2: 5 } at { x_advance: 9, y_advance: 0, x_offset: 0, y_offset: 0, var: 0 }
Glyph #3: { codepoint: 111, mask: 1, cluster: 3, var1: 2, var2: 5 } at { x_advance: 9, y_advance: 0, x_offset: 0, y_offset: 0, var: 0 }
Glyph #4: { codepoint: 110, mask: 1, cluster: 4, var1: 2, var2: 5 } at { x_advance: 5, y_advance: 0, x_offset: 0, y_offset: 0, var: 0 }
...
```
